### PR TITLE
fix: input safari focus

### DIFF
--- a/.changeset/dirty-rings-deliver.md
+++ b/.changeset/dirty-rings-deliver.md
@@ -1,0 +1,5 @@
+---
+'@consolelabs/theme': patch
+---
+
+Fix input outline

--- a/packages/theme/src/components/input.ts
+++ b/packages/theme/src/components/input.ts
@@ -2,7 +2,7 @@ import { cva, VariantProps } from 'class-variance-authority'
 
 const inputVariants = cva(
   [
-    'flex-1 h-fit outline-0 rounded border border-neutral-300 shadow-input text-neutral-800 placeholder:text-neutral-500 focus:border-primary-600 focus:shadow-input-focused',
+    'flex-1 h-fit focus:outline-none rounded border border-neutral-300 shadow-input text-neutral-800 placeholder:text-neutral-500 focus:border-primary-600 focus:shadow-input-focused',
   ],
   {
     variants: {


### PR DESCRIPTION
**What does this PR do?**

- [x] Disable browser's default input focus style

**Key Changes**
![image](https://github.com/consolelabs/web-foundation/assets/25856620/33410073-8c37-4948-8bfe-5462abf66d94)
**NOTE: I cannot reproduce this in local storybook but online documents have shown that to use `outline-none` instead of `outline-0` so maybe that will fix it**