### PR TITLE
chore: add discord notify github action

### DIFF
--- a/.github/actions/discord-notify/action.yml
+++ b/.github/actions/discord-notify/action.yml
@@ -1,0 +1,54 @@
+name: Discord release notify
+
+inputs:
+  github-token:
+    description: 'Token to access the github'
+    required: true
+  discord-webhook:
+    description: 'The Discord webhook URL'
+    required: true
+  tags-info:
+    description: 'JSON array of name and version of released tags'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Get current time
+      uses: josStorer/get-current-time@v2
+      id: current-time
+      with:
+        format: MMMM Do YYYY, h:mm a
+        utcOffset: '+07:00'
+
+    - name: Get Discord Content
+      id: discord-content
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const breakLine = "\n";
+          const tagsInfo = Array.from(${{ fromJson(inputs.tags-info) }})
+          const footer = "*Released at ${{ steps.current-time.outputs.formattedTime }}*";
+          const contentInfo = tagsInfo
+            .map((tag) => {
+              const name = tag.name;
+              const version = tag.version;
+              return `- **${name}** was released to version: **${version}**`;
+            })
+            .join(breakLine);
+          const info = [contentInfo, breakLine, footer].join("");
+          return [
+            {
+              title: "New releases! 🚀🚀🚀",
+              description: `${info}`,
+              color: 1127128,
+            },
+          ];
+
+    - name: Discord notification
+      uses: Ilshidur/action-discord@master
+      env:
+        DISCORD_WEBHOOK: ${{ inputs.discord-webhook }}
+        DISCORD_USERNAME: Github Release
+        DISCORD_AVATAR: https://cdn.discordapp.com/avatars/1176117154010120202/df91181b3f1cf0ef1592fbe18e0962d7.webp?size=80
+        DISCORD_EMBEDS: ${{ steps.discord-content.outputs.result }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          # see `fetch-depth` in README: https://github.com/actions/checkout#checkout-v3,
+          # see `fetch-depth` in README: https://github.com/actions/checkout#checkout-v4,
           # we set to `0` so the referenced commits are available for the command below
           fetch-depth: 0
 
@@ -44,6 +44,7 @@ jobs:
         run: pnpm build:packages
 
       - name: Create Release Pull Request or Publish Packages
+        id: changesets
         uses: changesets/action@v1
         with:
           publish: pnpm release
@@ -54,3 +55,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Send Discord Notify
+        if: steps.changesets.outputs.published == 'true'
+        uses: ./.github/actions/discord-notify
+        timeout-minutes: 10
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          discord-webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          tags-info: ${{ toJson(steps.changesets.outputs.publishedPackages) }}


### PR DESCRIPTION
**What does this PR do?**

- [x] add discord notify actions

**Note**: Add `DISCORD_WEBHOOK` to Github Secret variables before merge

![image](https://github.com/consolelabs/web-foundation/assets/71743905/7f3b26ec-34dc-47d6-8e9c-6a56443f3c3c)
