### PR TITLE
fix(button): update style for link variant

### DIFF
--- a/.changeset/small-steaks-kneel.md
+++ b/.changeset/small-steaks-kneel.md
@@ -1,0 +1,7 @@
+---
+'@consolelabs/theme': minor
+'@consolelabs/button': minor
+'@consolelabs/icon-button': minor
+---
+
+Update style for button link variant

--- a/packages/theme/src/colors/semantic.ts
+++ b/packages/theme/src/colors/semantic.ts
@@ -24,6 +24,7 @@ export const semanticColors = {
         hover: commonColors.primary['100'],
         active: commonColors.primary['100'],
         'disable-fg': commonColors.primary['400'],
+        'hover-fg': commonColors.primary['800'],
       },
     },
     secondary: {
@@ -48,6 +49,7 @@ export const semanticColors = {
         hover: commonColors.secondary['100'],
         active: commonColors.secondary['100'],
         'disable-fg': commonColors.secondary['400'],
+        'hover-fg': commonColors.secondary['800'],
       },
     },
     success: {
@@ -72,6 +74,7 @@ export const semanticColors = {
         hover: commonColors.success['100'],
         active: commonColors.success['100'],
         'disable-fg': commonColors.success['400'],
+        'hover-fg': commonColors.success['800'],
       },
     },
     warning: {
@@ -96,6 +99,7 @@ export const semanticColors = {
         hover: commonColors.warning['100'],
         active: commonColors.warning['100'],
         'disable-fg': commonColors.warning['400'],
+        'hover-fg': commonColors.warning['800'],
       },
     },
     danger: {
@@ -120,6 +124,7 @@ export const semanticColors = {
         hover: commonColors.danger['100'],
         active: commonColors.danger['100'],
         'disable-fg': commonColors.danger['400'],
+        'hover-fg': commonColors.danger['800'],
       },
     },
     neutral: {
@@ -144,6 +149,7 @@ export const semanticColors = {
         hover: commonColors.neutral['100'],
         active: commonColors.neutral['100'],
         'disable-fg': commonColors.neutral['400'],
+        'hover-fg': commonColors.neutral['800'],
       },
     },
     text: {

--- a/packages/theme/src/components/button.ts
+++ b/packages/theme/src/components/button.ts
@@ -6,7 +6,7 @@ const commonVariant = {
     solid: '',
     outline: 'shadow-button border',
     ghost: '',
-    link: 'p-0 rounded-md hover:underline',
+    link: 'bg-transparent',
   },
   color: {
     primary: '',
@@ -222,8 +222,8 @@ const commonCompoundVariants = [
     color: 'primary',
     className: [
       'text-primary-plain-fg',
+      'hover:text-primary-plain-hover-fg',
       'disabled:text-primary-plain-disable-fg',
-      'focus:shadow-small focus:shadow-primary-700/10',
     ],
   },
   {
@@ -231,8 +231,8 @@ const commonCompoundVariants = [
     color: 'secondary',
     className: [
       'text-secondary-plain-fg',
+      'hover:text-secondary-plain-hover-fg',
       'disabled:text-secondary-plain-disable-fg',
-      'focus:shadow-small focus:shadow-secondary-700/10',
     ],
   },
   {
@@ -240,8 +240,8 @@ const commonCompoundVariants = [
     color: 'success',
     className: [
       'text-success-plain-fg',
+      'hover:text-success-plain-hover-fg',
       'disabled:text-success-plain-disable-fg',
-      'focus:shadow-small focus:shadow-success-700/10',
     ],
   },
   {
@@ -249,8 +249,8 @@ const commonCompoundVariants = [
     color: 'danger',
     className: [
       'text-danger-plain-fg',
+      'hover:text-danger-plain-hover-fg',
       'disabled:text-danger-plain-disable-fg',
-      'focus:shadow-small focus:shadow-danger-700/10',
     ],
   },
   {
@@ -258,8 +258,8 @@ const commonCompoundVariants = [
     color: 'warning',
     className: [
       'text-warning-plain-fg',
+      'hover:text-warning-plain-hover-fg',
       'disabled:text-warning-plain-disable-fg',
-      'focus:shadow-small focus:shadow-warning-700/10',
     ],
   },
   {
@@ -267,8 +267,8 @@ const commonCompoundVariants = [
     color: 'neutral',
     className: [
       'text-neutral-plain-fg',
+      'hover:text-neutral-plain-hover-fg',
       'disabled:text-neutral-plain-disable-fg',
-      'focus:shadow-small focus:shadow-neutral-700/10',
     ],
   },
 ] as const
@@ -292,17 +292,17 @@ const buttonCva = cva(
     },
     compoundVariants: [
       {
-        variant: ['solid', 'outline', 'ghost'],
+        variant: ['solid', 'outline', 'ghost', 'link'],
         size: 'sm',
         className: 'px-4 h-[34px] rounded',
       },
       {
-        variant: ['solid', 'outline', 'ghost'],
+        variant: ['solid', 'outline', 'ghost', 'link'],
         size: 'md',
         className: 'px-4 h-10 rounded-lg',
       },
       {
-        variant: ['solid', 'outline', 'ghost'],
+        variant: ['solid', 'outline', 'ghost', 'link'],
         size: 'lg',
         className: 'px-6 h-12 rounded-lg',
       },


### PR DESCRIPTION
Update styles for link variant:

- [x] remove underline + outline + background when hover
- [x] re-enable padding
- [x] hover to change foreground to color weight 800

<img width="401" alt="image" src="https://github.com/consolelabs/web-foundation/assets/12707960/d02cb201-d26c-42fe-8f40-c0b42a7af711">
